### PR TITLE
ヘッダーの検索ボタン追加

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -2,7 +2,7 @@ import Logo from '@components/icons/Logo'
 import SeachButton from '@components/SearchButton'
 const Header = () => {
   return (
-    <header>
+    <header className="flex justify-between items-center p-32px">
       <Logo />
       <SeachButton />
     </header>

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -10,7 +10,7 @@ type Props = {
 const Layout = ({ children }: Props) => (
   <div className="min-h-screen">
     <Header />
-    {children}
+    <main className="font-Montserrat">{children}</main>
     <Footer />
   </div>
 )

--- a/frontend/components/SearchButton.tsx
+++ b/frontend/components/SearchButton.tsx
@@ -1,8 +1,14 @@
-/* NEXT TASK */
-const SearchButton = () => (
-  <div>
-    <button>aaa</button>
-    <button>bbb</button>
-  </div>
-)
+import SearchIcon from '@components/icons/SearchIcon'
+
+const SearchButton = () => {
+  return (
+    <div className="border rounded-search flex font-Mulish cursor-pointer">
+      <p className="p-5 border-r border-gray-2">dummy word</p>
+      <p className="p-5 border-r border-gray-2">4 guest</p>
+      <div className="p-5 ">
+        <SearchIcon width="18px" height="18px" className="fill-red" />
+      </div>
+    </div>
+  )
+}
 export default SearchButton

--- a/frontend/components/icons/SearchIcon.tsx
+++ b/frontend/components/icons/SearchIcon.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  width?: string | number
+  height?: string | number
+  className: string
+}
+const SearchIcon = ({ className, height = 18, width = 18 }: Props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={height}
+    viewBox="0 0 20 20"
+    width={width}
+    className={className}
+  >
+    <path d="M0 0h24v24H0V0z" fill="none" />
+    <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+  </svg>
+)
+export default SearchIcon

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -6,7 +6,6 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: Montserrat;
   font-size: 14px;
 }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -3,15 +3,29 @@ module.exports = {
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
+    fill: (theme) => ({ red: theme('colors.red.1') }),
+    fontFamily: {
+      Montserrat: ['Montserrat'],
+      Mulish: ['Mulish'],
+    },
     extend: {
       spacing: {
         7.5: '1.875rem',
+        '16px': '16px',
+        '32px': '32px',
       },
       colors: {
         black: '#333',
         gray: {
           1: '#828282',
+          2: '#F2F2F2',
         },
+        red: {
+          1: '#EB5757',
+        },
+      },
+      borderRadius: {
+        search: '1.14rem',
       },
     },
   },


### PR DESCRIPTION
## やったこと
- デザイン通りにヘッダーボタンを追加

## やらなかったこと
- tailwindのconfigはいったん適当。もう少し見えてきてから整理する
- 検索ボタン押下後のメニュー未実装
- 検索ボタンイベント未実装
- remとpxの使い分けをREADMEに記載